### PR TITLE
Fix accumulating taxes issue when Avalara is disabled

### DIFF
--- a/app/models/spree/calculator/avalara_transaction.rb
+++ b/app/models/spree/calculator/avalara_transaction.rb
@@ -11,6 +11,8 @@ module Spree
     end
 
     def compute_shipment_or_line_item(item)
+      return 0 unless ::Spree::Avatax::Config.tax_calculation
+
       order = item.order
 
       if can_calculate_tax?(order)

--- a/spec/models/spree/calculator/avalara_transaction_spec.rb
+++ b/spec/models/spree/calculator/avalara_transaction_spec.rb
@@ -63,11 +63,11 @@ RSpec.describe Spree::Calculator::AvalaraTransaction do
         expect(calculator.compute(line_item)).to eq(0.1)
       end
 
-      it 'is equal to the previous tax total if preference tax_calculation is false' do
+      it 'is zero if preference tax_calculation is false' do
         Spree::Avatax::Config.tax_calculation = false
 
         line_item.additional_tax_total = 0.1
-        expect(calculator.compute(line_item)).to eq(0.1)
+        expect(calculator.compute(line_item)).to be_zero
       end
 
       context 'when the order is discounted' do

--- a/spec/vcr/Spree_Calculator_AvalaraTransaction/_compute_line_item/when_tax_is_not_included_in_price/is_zero_if_preference_tax_calculation_is_false.yml
+++ b/spec/vcr/Spree_Calculator_AvalaraTransaction/_compute_line_item/when_tax_is_not_included_in_price/is_zero_if_preference_tax_calculation_is_false.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://sandbox-rest.avatax.com/api/v2/transactions/createoradjust
+    body:
+      encoding: UTF-8
+      string: '{"createTransactionModel":{"code":"R235022225","date":"2025-07-10","discount":"0.0","commit":false,"type":"SalesOrder","lines":[{"number":"1-LI","description":"Product
+        #7 - 1712","taxCode":"TaxCode - 599889","itemCode":"SKU-7","quantity":1,"amount":10.0,"discounted":false,"taxIncluded":false,"addresses":{"shipFrom":{"line1":"1600
+        Pennsylvania Ave NW","line2":null,"city":"Washington","region":"AL","country":"US","postalCode":"20500"},"shipTo":{"line1":"A
+        Different Road","line2":"Northwest","city":"Herndon","region":"AL","country":"US","postalCode":"10014"}},"customerUsageType":null,"businessIdentificationNo":null,"exemptionCode":null},{"number":"1-FR","itemCode":"Avalara
+        Ground","quantity":1,"amount":100.0,"description":"Shipping Charge","taxCode":"FR000000","discounted":false,"taxIncluded":false,"addresses":{"shipFrom":{"line1":"1600
+        Pennsylvania Ave NW","line2":null,"city":"Washington","region":"AL","country":"US","postalCode":"20500"},"shipTo":{"line1":"A
+        Different Road","line2":"Northwest","city":"Herndon","region":"AL","country":"US","postalCode":"10014"}},"customerUsageType":null,"businessIdentificationNo":null,"exemptionCode":null}],"customerCode":1,"companyCode":"DEFAULT","customerUsageType":null,"exemptionNo":null,"referenceCode":"R235022225","currencyCode":"USD","businessIdentificationNo":null}}'
+    headers:
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - AvaTax Ruby Gem 25.6.2
+      X-Avalara-Client:
+      - ";;RubySdk;25.6.2;"
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic MTIzNDU6MTIzNDU=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Thu, 10 Jul 2025 14:12:10 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, no-cache, no-store
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - same-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Correlation-Id:
+      - 461780c8-d553-4490-98ae-ff894e0a2cb5
+      X-Avalara-Uid:
+      - 461780c8-d553-4490-98ae-ff894e0a2cb5
+    body:
+      encoding: UTF-8
+      string: '{"error": {"code": "AuthenticationException","message": "Authentication
+        failed.","details": [{"code": "AuthenticationException","message": "Authentication
+        failed.","description": "Missing authentication or unable to authenticate
+        the user or the account.","faultCode": "Client","helpLink": "http://developer.avalara.com/avatax/errors/AuthenticationException"}]}}'
+  recorded_at: Thu, 10 Jul 2025 14:12:10 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
When a product has both an Avalara tax rate and an additional standard Solidus tax rate, disabling Avalara could cause taxes to accumulate with each order recalculation. This happens because the Avalara calculator returns the current tax amount for the line item — which already includes the standard Solidus tax — even when Avalara is turned off. As a result, this amount is repeatedly added to the existing taxes, causing them to increase unnecessarily.