### PR TITLE
Normalize address representation for address2

### DIFF
--- a/app/models/concerns/to_avatax_hash.rb
+++ b/app/models/concerns/to_avatax_hash.rb
@@ -4,7 +4,7 @@ module ToAvataxHash
   def to_avatax_hash
     {
       line1: address1,
-      line2: address2,
+      line2: address2.presence,
       city: city,
       region: state.try(:abbr),
       country: country.try(:iso),

--- a/spec/concerns/to_avatax_hash_spec.rb
+++ b/spec/concerns/to_avatax_hash_spec.rb
@@ -3,15 +3,29 @@
 require 'spec_helper'
 
 describe ToAvataxHash do
-  it 'with Spree::Address' do
-    address = create(:address)
+  subject { address.to_avatax_hash }
 
-    expect(address.to_avatax_hash).to be_kind_of(Hash)
+  context "with Spree::Address" do
+    let(:address) { build(:address) }
+
+    it { is_expected.to be_kind_of(Hash) }
+
+    context "with no address2" do
+      before { address.address2 = nil }
+
+      it { expect(subject[:line2]).to be_nil }
+    end
+
+    context "with empty address2" do
+      before { address.address2 = "" }
+
+      it { expect(subject[:line2]).to be_nil }
+    end
   end
 
-  it 'with Spree::StockLocation' do
-    address = create(:stock_location)
+  context "with Spree::StockLocation" do
+    let(:address) { build(:stock_location) }
 
-    expect(address.to_avatax_hash).to be_kind_of(Hash)
+    it { is_expected.to be_kind_of(Hash) }
   end
 end


### PR DESCRIPTION
This change ensures consistent handling of address2 in the hash representation by returning nil when address2 is either nil or an empty string. Previously, empty strings would be included in the hash, causing inconsistent behavior.