### PR TITLE
Remove `Address not geocoded` error message on failed address validation

### DIFF
--- a/app/decorators/models/solidus_avatax_certified/spree/order_decorator.rb
+++ b/app/decorators/models/solidus_avatax_certified/spree/order_decorator.rb
@@ -3,6 +3,8 @@
 module SolidusAvataxCertified
   module Spree
     module OrderDecorator
+      ADDRESS_NOT_GEOCODED_MESSAGE = "Address not geocoded".freeze
+
       def self.prepended(base)
         base.has_one :avalara_transaction, dependent: :destroy
 
@@ -50,6 +52,14 @@ module SolidusAvataxCertified
         return response if !::Spree::Avatax::Config.refuse_checkout_address_validation_error
 
         response.summary_messages.each do |msg|
+          if msg.include?(ADDRESS_NOT_GEOCODED_MESSAGE)
+            if response.summary_messages.size <= 1
+              errors.add(:base, I18n.t("spree.ship_address_required"))
+            end
+
+            next
+          end
+
           errors.add(:address_validation_failure, msg)
         end
 

--- a/spec/vcr/Spree_Order/_validate_ship_address/validation_failed/when_Spree_Avatax_Config_refuse_checkout_address_validation_error_is_false/adds_the_proper_error_message_to_the_order.yml
+++ b/spec/vcr/Spree_Order/_validate_ship_address/validation_failed/when_Spree_Avatax_Config_refuse_checkout_address_validation_error_is_false/adds_the_proper_error_message_to_the_order.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox-rest.avatax.com/api/v2/addresses/resolve?city=Fooobar&country=US&line1=1234%20Foobar%20St&line2=Northwest&postalCode=foobar&region=NY
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - AvaTax Ruby Gem 25.6.2
+      X-Avalara-Client:
+      - ";;RubySdk;25.6.2;"
+      Authorization:
+      - Basic MjAwNzIxMTMzMjo2MThEM0Y3NjdGMzhBOTg1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 17 Jul 2025 08:39:56 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, no-cache, no-store
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - same-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Correlation-Id:
+      - a5df387b-2bbe-4e8c-9280-4d2dadc39ff7
+      X-Avalara-Uid:
+      - a5df387b-2bbe-4e8c-9280-4d2dadc39ff7
+      Serverduration:
+      - '00:00:00.0031284'
+      Api-Supported-Versions:
+      - '2.0'
+    body:
+      encoding: UTF-8
+      string: '{"address":{"line1":"1234 Foobar St","line2":"Northwest","city":"Fooobar","region":"NY","country":"US","postalCode":"foobar"},"validatedAddresses":[{"addressType":"UnknownAddressType","line1":"1234
+        Foobar St","line2":"Northwest","line3":"","city":"Fooobar","region":"NY","country":"US","postalCode":"foobar"}],"resolutionQuality":"External","messages":[{"summary":"Address
+        not geocoded.","details":"Address cannot be geocoded.","refersTo":"Address","severity":"Error","source":"Avalara.AvaTax.Common"},{"summary":"The
+        city could not be determined.","details":"The city could not be found or determined
+        from postal code.","refersTo":"Address.City","severity":"Error","source":"Avalara.AvaTax.Common"}]}'
+  recorded_at: Thu, 17 Jul 2025 08:39:56 GMT
+recorded_with: VCR 6.3.1

--- a/spec/vcr/Spree_Order/_validate_ship_address/validation_failed/when_Spree_Avatax_Config_refuse_checkout_address_validation_error_is_false/raise_exceptions_if_raise_exceptions_preference_is_enabled.yml
+++ b/spec/vcr/Spree_Order/_validate_ship_address/validation_failed/when_Spree_Avatax_Config_refuse_checkout_address_validation_error_is_false/raise_exceptions_if_raise_exceptions_preference_is_enabled.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox-rest.avatax.com/api/v2/addresses/resolve?city&country=US&line1&line2=Northwest&postalCode&region=NY
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - AvaTax Ruby Gem 25.6.2
+      X-Avalara-Client:
+      - ";;RubySdk;25.6.2;"
+      Authorization:
+      - Basic MjAwNzIxMTMzMjo2MThEM0Y3NjdGMzhBOTg1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Thu, 17 Jul 2025 08:53:05 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, no-cache, no-store
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - same-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Correlation-Id:
+      - 14330862-70bd-433f-84f1-080f4097f302
+      X-Avalara-Uid:
+      - 14330862-70bd-433f-84f1-080f4097f302
+      Serverduration:
+      - '00:00:00.0001916'
+      Api-Supported-Versions:
+      - '2.0'
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"InvalidAddress","message":"The address value was
+        incomplete.","target":"IncorrectData","details":[{"code":"InvalidAddress","number":309,"message":"The
+        address value was incomplete.","description":"The address value NULL was incomplete.
+        You must provide either a valid postal code, line1 + city + region, or line1
+        + postal code.","faultCode":"Client","helpLink":"https://developer.avalara.com/avatax/errors/InvalidAddress","severity":"Error"}]}}'
+  recorded_at: Thu, 17 Jul 2025 08:53:05 GMT
+recorded_with: VCR 6.3.1

--- a/spec/vcr/Spree_Order/_validate_ship_address/validation_failed/when_Spree_Avatax_Config_refuse_checkout_address_validation_error_is_true/adds_the_proper_error_message_to_the_order.yml
+++ b/spec/vcr/Spree_Order/_validate_ship_address/validation_failed/when_Spree_Avatax_Config_refuse_checkout_address_validation_error_is_true/adds_the_proper_error_message_to_the_order.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sandbox-rest.avatax.com/api/v2/addresses/resolve?city=Fooobar&country=US&line1=1234%20Foobar%20St&line2=Northwest&postalCode=foobar&region=NY
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - AvaTax Ruby Gem 25.6.2
+      X-Avalara-Client:
+      - ";;RubySdk;25.6.2;"
+      Authorization:
+      - Basic MjAwNzIxMTMzMjo2MThEM0Y3NjdGMzhBOTg1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 17 Jul 2025 08:39:21 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, no-cache, no-store
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - sameorigin
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - same-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Correlation-Id:
+      - e7a6d8da-71b9-4b49-b36f-0628f4e7ec54
+      X-Avalara-Uid:
+      - e7a6d8da-71b9-4b49-b36f-0628f4e7ec54
+      Serverduration:
+      - '00:00:00.0046676'
+      Api-Supported-Versions:
+      - '2.0'
+    body:
+      encoding: UTF-8
+      string: '{"address":{"line1":"1234 Foobar St","line2":"Northwest","city":"Fooobar","region":"NY","country":"US","postalCode":"foobar"},"validatedAddresses":[{"addressType":"UnknownAddressType","line1":"1234
+        Foobar St","line2":"Northwest","line3":"","city":"Fooobar","region":"NY","country":"US","postalCode":"foobar"}],"resolutionQuality":"External","messages":[{"summary":"Address
+        not geocoded.","details":"Address cannot be geocoded.","refersTo":"Address","severity":"Error","source":"Avalara.AvaTax.Common"},{"summary":"The
+        city could not be determined.","details":"The city could not be found or determined
+        from postal code.","refersTo":"Address.City","severity":"Error","source":"Avalara.AvaTax.Common"}]}'
+  recorded_at: Thu, 17 Jul 2025 08:39:21 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
The "Address not geocoded" message is not meaningful to customers, so it has been removed.

Based on experience, this message typically appears alongside more specific ones, such as "The city could not be determined," making its removal inconsequential.

In cases where no other message is present, customers will see a generic error from the translation key spree.ship_address_required, which states "Valid shipping address required." This translation comes from Solidus.