### PR TITLE
Do not block checkout on address validation low level errors

### DIFF
--- a/app/models/solidus_avatax_certified/response/address_validation.rb
+++ b/app/models/solidus_avatax_certified/response/address_validation.rb
@@ -16,6 +16,8 @@ module SolidusAvataxCertified
       end
 
       def messages
+        return unless result
+
         @messages ||= result['messages']
       end
 
@@ -24,11 +26,15 @@ module SolidusAvataxCertified
       end
 
       def error?
+        return false if suppress_exceptions?
+
         result['error'].present?
       end
 
       def failed?
-        error? || messages_present? && messages.any? { |m| m['severity'] == 'Error' }
+        return false if suppress_exceptions?
+
+        error? || errors_present?
       end
 
       def messages_present?
@@ -53,6 +59,16 @@ module SolidusAvataxCertified
         else
           []
         end
+      end
+
+      private
+
+      def suppress_exceptions?
+        !::Spree::Avatax::Config.raise_exceptions && !result
+      end
+
+      def errors_present?
+        messages_present? && messages.any? { |m| m['severity'] == 'Error' }
       end
     end
   end

--- a/spec/models/solidus_avatax_certified/response/address_validation_spec.rb
+++ b/spec/models/solidus_avatax_certified/response/address_validation_spec.rb
@@ -5,99 +5,27 @@ require 'spec_helper'
 RSpec.describe SolidusAvataxCertified::Response::AddressValidation do
   let(:response) { described_class.new(response_hash) }
 
-  before do
-    allow(response.faraday).to receive(:body).and_return(response_hash)
-  end
-
-  context 'Successful Response' do
-    let(:response_hash) { build(:address_validation_success) }
-
-    it '#validated_address' do
-      validated_address = response.validated_address
-
-      expect(validated_address['addressType']).to eq('HighRiseOrBusinessComplex')
-      expect(validated_address['line1']).to eq('10 MOUNT PLEASANT AVE')
+  context "Successful API interactions" do
+    before do
+      allow(response.faraday).to receive(:body).and_return(response_hash)
     end
 
-    it '#messages' do
-      expect(response.messages).to be_nil
-    end
-
-    it '#success?' do
-      expect(response).to be_success
-    end
-
-    it '#error?' do
-      expect(response).not_to be_error
-    end
-
-    it '#failed?' do
-      expect(response).not_to be_failed
-    end
-
-    it '#messages_present?' do
-      expect(response).not_to be_messages_present
-    end
-
-    it '#summary_messages' do
-      expect(response.summary_messages).to eq([])
-    end
-
-    it '#detailed_messages' do
-      expect(response.detailed_messages).to eq([])
-    end
-  end
-
-  context 'Error Response' do
-    context 'Missing Attributes' do
-      let(:response_hash) { build(:address_validation_error) }
+    context 'Successful Response' do
+      let(:response_hash) { build(:address_validation_success) }
 
       it '#validated_address' do
-        expect(response.validated_address).to eq({})
+        validated_address = response.validated_address
+
+        expect(validated_address['addressType']).to eq('HighRiseOrBusinessComplex')
+        expect(validated_address['line1']).to eq('10 MOUNT PLEASANT AVE')
+      end
+
+      it '#messages' do
+        expect(response.messages).to be_nil
       end
 
       it '#success?' do
-        expect(response).not_to be_success
-      end
-
-      it '#error?' do
-        expect(response).to be_error
-      end
-
-      it '#failed?' do
-        expect(response).to be_failed
-      end
-
-      it '#messages_present?' do
-        expect(response).not_to be_messages_present
-      end
-
-      it '#summary_messages' do
-        summaries = response.summary_messages
-
-        expect(summaries).to be_kind_of Array
-        expect(summaries.length).to eq(1)
-        expect(summaries.first).to eq('The address value was incomplete.')
-      end
-
-      it '#detailed_messages' do
-        details = response.detailed_messages
-
-        expect(details).to be_kind_of Array
-        expect(details.length).to eq(1)
-        expect(details.first).to eq('The address value  was incomplete.  You must provide either a valid postal code, line1 + city + region, or latitude + longitude.  For international transactions outside of US/CA, only a country code is required.')
-      end
-    end
-
-    context 'Unknown Address' do
-      let(:response_hash) { build(:address_validation_unknown) }
-
-      it '#validated_address' do
-        expect(response.validated_address).to be_empty
-      end
-
-      it '#success?' do
-        expect(response).not_to be_success
+        expect(response).to be_success
       end
 
       it '#error?' do
@@ -105,25 +33,99 @@ RSpec.describe SolidusAvataxCertified::Response::AddressValidation do
       end
 
       it '#failed?' do
-        expect(response).to be_failed
+        expect(response).not_to be_failed
       end
 
       it '#messages_present?' do
-        expect(response).to be_messages_present
+        expect(response).not_to be_messages_present
       end
 
       it '#summary_messages' do
-        summaries = response.summary_messages
-
-        expect(summaries).to be_kind_of Array
-        expect(summaries.first).to eq('The address is not deliverable.')
+        expect(response.summary_messages).to eq([])
       end
 
       it '#detailed_messages' do
-        details = response.detailed_messages
+        expect(response.detailed_messages).to eq([])
+      end
+    end
 
-        expect(details).to be_kind_of Array
-        expect(details.first).to eq('The physical location exists but there are no homes on this street. One reason might be railroad tracks or rivers running alongside this street, as they would prevent construction of homes in this location.')
+    context 'Error Response' do
+      context 'Missing Attributes' do
+        let(:response_hash) { build(:address_validation_error) }
+
+        it '#validated_address' do
+          expect(response.validated_address).to eq({})
+        end
+
+        it '#success?' do
+          expect(response).not_to be_success
+        end
+
+        it '#error?' do
+          expect(response).to be_error
+        end
+
+        it '#failed?' do
+          expect(response).to be_failed
+        end
+
+        it '#messages_present?' do
+          expect(response).not_to be_messages_present
+        end
+
+        it '#summary_messages' do
+          summaries = response.summary_messages
+
+          expect(summaries).to be_kind_of Array
+          expect(summaries.length).to eq(1)
+          expect(summaries.first).to eq('The address value was incomplete.')
+        end
+
+        it '#detailed_messages' do
+          details = response.detailed_messages
+
+          expect(details).to be_kind_of Array
+          expect(details.length).to eq(1)
+          expect(details.first).to eq('The address value  was incomplete.  You must provide either a valid postal code, line1 + city + region, or latitude + longitude.  For international transactions outside of US/CA, only a country code is required.')
+        end
+      end
+
+      context 'Unknown Address' do
+        let(:response_hash) { build(:address_validation_unknown) }
+
+        it '#validated_address' do
+          expect(response.validated_address).to be_empty
+        end
+
+        it '#success?' do
+          expect(response).not_to be_success
+        end
+
+        it '#error?' do
+          expect(response).not_to be_error
+        end
+
+        it '#failed?' do
+          expect(response).to be_failed
+        end
+
+        it '#messages_present?' do
+          expect(response).to be_messages_present
+        end
+
+        it '#summary_messages' do
+          summaries = response.summary_messages
+
+          expect(summaries).to be_kind_of Array
+          expect(summaries.first).to eq('The address is not deliverable.')
+        end
+
+        it '#detailed_messages' do
+          details = response.detailed_messages
+
+          expect(details).to be_kind_of Array
+          expect(details.first).to eq('The physical location exists but there are no homes on this street. One reason might be railroad tracks or rivers running alongside this street, as they would prevent construction of homes in this location.')
+        end
       end
     end
   end

--- a/spec/models/solidus_avatax_certified/response/address_validation_spec.rb
+++ b/spec/models/solidus_avatax_certified/response/address_validation_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe SolidusAvataxCertified::Response::AddressValidation do
     context 'Successful Response' do
       let(:response_hash) { build(:address_validation_success) }
 
+      it { expect(response.result).not_to be_nil }
+
       it '#validated_address' do
         validated_address = response.validated_address
 
@@ -52,6 +54,8 @@ RSpec.describe SolidusAvataxCertified::Response::AddressValidation do
     context 'Error Response' do
       context 'Missing Attributes' do
         let(:response_hash) { build(:address_validation_error) }
+
+        it { expect(response.result).not_to be_nil }
 
         it '#validated_address' do
           expect(response.validated_address).to eq({})
@@ -93,6 +97,8 @@ RSpec.describe SolidusAvataxCertified::Response::AddressValidation do
       context 'Unknown Address' do
         let(:response_hash) { build(:address_validation_unknown) }
 
+        it { expect(response.result).not_to be_nil }
+
         it '#validated_address' do
           expect(response.validated_address).to be_empty
         end
@@ -126,6 +132,58 @@ RSpec.describe SolidusAvataxCertified::Response::AddressValidation do
           expect(details).to be_kind_of Array
           expect(details.first).to eq('The physical location exists but there are no homes on this street. One reason might be railroad tracks or rivers running alongside this street, as they would prevent construction of homes in this location.')
         end
+      end
+    end
+  end
+
+  context "On failed API interactions (socket errors, timeouts)" do
+    let(:response_hash) { {"error" => {"message" => "SocketError"}} }
+
+    context "when raise_exceptions is true" do
+      before do
+        allow(::Spree::Avatax::Config).to receive(:raise_exceptions).and_return(true)
+      end
+
+      it { expect(response.result).to be_nil }
+
+      it "#success?" do
+        expect { response.success? }.to raise_error
+      end
+
+      it "#messages" do
+        expect(response.messages).to be_nil
+      end
+
+      it "#error?" do
+        expect { response.error? }.to raise_error
+      end
+
+      it "#failed?" do
+        expect { response.failed? }.to raise_error
+      end
+    end
+
+    context "when raise_exceptions is false" do
+      before do
+        allow(::Spree::Avatax::Config).to receive(:raise_exceptions).and_return(false)
+      end
+
+      it { expect(response.result).to be_nil }
+
+      it "#success?" do
+        expect(response).to be_success
+      end
+
+      it "#messages" do
+        expect(response.messages).to be_nil
+      end
+
+      it "#error?" do
+        expect(response).not_to be_error
+      end
+
+      it "#failed?" do
+        expect(response).not_to be_failed
       end
     end
   end


### PR DESCRIPTION
We don't want to block the checkout when the Avatax service is down, or timeouts, or anything unexpected and unrelated to address validation that could prevent the customer from checking out their carts.

This is a quick and dirty solution to get us going, in case of errors the class instance methods may not be fully coherent and working but this is enough to keep moving the order forward without blocking the checkout.

A better and more comprehensive solution would be to rework the way errors are managed starting from `TaxSvc#validate_address` [1] but this would require more extensive rework.

Original specs are retained but reworked so they can be integrated in the next commit separately for clarity with new ones that verify this change.

[1] https://github.com/watg/solidus_avatax_certified/blob/master/app/models/tax_svc.rb#L29-L36